### PR TITLE
adding changing versions info

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ You can add all available Ziggeo-related options here:
 #### Demo
 A demo is located in the root [`demo`](https://github.com/Ziggeo/vue-ziggeo/tree/master/demo) folder.
 
+#### Changing versions
+Our Vue SDK is updated as new revisions of our client JS SDK come out, however you might want to grab a specific one, even before it is added or afterwards. If that is the case you can do that by modifying your package.json file to specify the version you want to use.
+
+In your `package.json` file you will have a section called `"devDependencies": {}` in it just add the specific details you want to be used like so (an example only):
+```
+"devDependencies": {
+  ...
+  "ziggeo-client-sdk": "2.32.1"
+}
+```
+* This would make your own repository use our 2.32.1 version of our system. In case our Vue SDK requires higher version that you have set up you would be alerted when you do `npm install`.
+
 #### Changelog
 - v0.1.0 upgraded to ziggeo 0.0.30 version and added screen recorder option
 - v0.2.0 Fixed countdown related conflict


### PR DESCRIPTION
Just adding info on how to manually set up which revision should be used in the Vue repository if some newer revision contains the needed update, or in cases where there is a preference to stay on specific revision until manual update.